### PR TITLE
Option, dass der Spieler sich beim Tragen nicht bewegen kann

### DIFF
--- a/Assets/Scripts/UpPicker.cs
+++ b/Assets/Scripts/UpPicker.cs
@@ -24,18 +24,18 @@ public class UpPicker : MonoBehaviour
     void Update()
     {
         if (carryAction.WasPressedThisFrame()) {
-            Debug.Log("Action was pressed");
             PickUp();
         }
 
         if (shootAction.WasPressedThisFrame()) {
             carriedObject.Shoot(shootingStrength);
+            carriedObject = null;
         }
     }
 
     void PickUp()
     {
-        if (carriedObject != null) {
+        if (IsCurrentlyCarrying()) {
             carriedObject.Drop();
             carriedObject = null;
             return;
@@ -48,15 +48,18 @@ public class UpPicker : MonoBehaviour
         Ray ray = mainCamera.ScreenPointToRay(screenCenter);
             if (Physics.Raycast(ray, out RaycastHit hit))
             {
-                Debug.Log("Ray Hit Something");
                 // Check if the clicked object is carryable
                 CarryAndShoot carryAndShoot = hit.collider.GetComponent<CarryAndShoot>();
                 if (carryAndShoot != null && Vector3.Distance(transform.position, hit.transform.position) < distanceToPickUp)
                 {
-                    Debug.Log("Hit a carryable Item");
                     carryAndShoot.Carry();
                     carriedObject = carryAndShoot;
                 }
             }
+    }
+
+    public bool IsCurrentlyCarrying()
+    {
+        return carriedObject != null;
     }
 }


### PR DESCRIPTION
Heyo,

Das Skript `CameraController` hat jetzt die Option `Stand Still When Carrying`. Wenn ihr die im Editor ankreuzt, kann sich der Spieler nicht bewegen, während er etwas trägt. Zumindest in x- und z-Richtung. Die y-Richtung musste ich lassen, damit Gravitation weiter funktionert. Also wenn ihr Springen implementieren wollt, muss man das Skript nochmal anpassen.

Die Kamera muss dafür natürlich auch das Skript `UpPicker` haben.

Löst #3 ohne die Speed-Anpassung